### PR TITLE
feat: 上传预览、历史优化、IndexedDB 支持

### DIFF
--- a/index.css
+++ b/index.css
@@ -1066,3 +1066,165 @@ button#drawer-close:hover {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Upload file preview ────────────────────────────────────── */
+.upload-zone--has-files .upload-icon,
+.upload-zone--has-files .upload-zone-title,
+.upload-zone--has-files .upload-zone-paste-hint { display: none; }
+
+.upload-zone--has-files .upload-zone-hint {
+  font-size: 12px;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.upload-zone--has-files .upload-zone-content {
+  padding: 10px 14px;
+}
+
+.file-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.file-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px 5px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  min-width: 0;
+  max-width: 100%;
+  transition: border-color 0.15s, background-color 0.3s;
+}
+
+.file-card:hover { border-color: var(--border-primary); }
+
+.file-card-thumb {
+  width: 34px;
+  height: 34px;
+  object-fit: contain;
+  border-radius: 4px;
+  background: var(--surface-alt);
+  flex-shrink: 0;
+}
+
+.file-card-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color 0.3s;
+}
+
+.file-card-remove {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: var(--text-muted);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  line-height: 18px;
+  text-align: center;
+  padding: 0;
+  transition: background-color 0.15s;
+}
+
+.file-card-remove:hover { background: #ef4444; }
+
+/* ── History card (updated layout) ─────────────────────────── */
+.history-item { align-items: flex-start; }
+
+.history-info {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+
+.history-info-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+}
+
+.history-name { flex: 1; }
+
+.history-params {
+  font-size: 10px;
+  color: var(--text-muted);
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: color 0.3s, background-color 0.3s, border-color 0.3s;
+}
+
+.history-delete-btn {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  line-height: 1.6;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.history-delete-btn:hover {
+  background: rgba(239, 68, 68, 0.08);
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.history-copy-btns {
+  display: flex;
+  gap: 4px;
+}
+
+button.history-copy-btn {
+  padding: 2px 8px;
+  border-radius: 3px;
+  background: var(--primary-muted);
+  color: var(--primary);
+  font-size: 10px;
+  font-weight: 600;
+  border: 1px solid var(--border-primary);
+  cursor: pointer;
+  line-height: 1.6;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+button.history-copy-btn:hover {
+  background: var(--primary);
+  color: white;
+}
+
+/* ── Storage indicator ──────────────────────────────────────── */
+.storage-badge {
+  display: inline-block;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  margin-left: 8px;
+  vertical-align: middle;
+  transition: color 0.3s, border-color 0.3s;
+}

--- a/index.html
+++ b/index.html
@@ -7,28 +7,26 @@
   <title>图片转Base64 - 在线图像Base64编码工具 | 支持JPG/PNG/SVG/GIF</title>
   <meta name="description" content="免费在线图片转Base64工具！即时将JPG、PNG、SVG、GIF等图像转换为Base64编码格式，无需上传文件，保护隐私，快速生成Data URL代码。">
   <meta name="keywords" content="图片转base64,image to base64,svg转base64,base64编码工具,在线图片转码,data url生成器,base64转换,image转base64,图片base64编码,jpg转base64,png转base64">
-  <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgdmlld0JveD0iMCAwIDMyIDMyIj48cmVjdCB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHJ4PSI2IiBmaWxsPSJ1cmwoI2dyYWQpIi8+PHJlY3QgeD0iNiIgeT0iMTAiIHdpZHRoPSI4IiBoZWlnaHQ9IjgiIGZpbGw9IiNmZmYiIHJ4PSIxIi8+PHBhdGggZD0iTTYgMTAgTDEwIDYgTDE0IDEwIFoiIGZpbGw9IiNmZmYiLz48cGF0aCBkPSJNMTYgMTYgTDIwIDEzIEwyMCAxOSBaIiBmaWxsPSIjZmZmIi8+PHJlY3QgeD0iMTgiIHk9IjE1IiB3aWR0aD0iMiIgaGVpZ2h0PSIyIiBmaWxsPSIjZmZmIi8+PHJlY3QgeD0iMjIiIHk9IjEyIiB3aWR0aD0iOCIgaGVpZ2h0PSIyIiBmaWxsPSIjZmZmIiByeD0iMSIvPjxyZWN0IHg9IjIyIiB5PSIxOCIgd2lkdGg9IjgiIGhlaWdodD0iMiIgZmlsbD0iI2ZmZiIgcng9IjEiLz48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImdyYWQiIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIxIj48c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNkE3OGY4Ii8+PHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjNGYzOGNhIi8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PC9zdmc+">
+  <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgdmlld0JveD0iMCAwIDMyIDMyIj48cmVjdCB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHJ4PSI2IiBmaWxsPSJ1cmwoI2cpIi8+PHJlY3QgeD0iNiIgeT0iMTAiIHdpZHRoPSI4IiBoZWlnaHQ9IjgiIGZpbGw9IiNmZmYiIHJ4PSIxIi8+PHBhdGggZD0iTTYgMTBMMTAgNkwxNCAxMFoiIGZpbGw9IiNmZmYiLz48cGF0aCBkPSJNMTYgMTZMMjAgMTIuNUwyMCAxOS41WiIgZmlsbD0iI2ZmZiIvPjxyZWN0IHg9IjE4IiB5PSIxNSIgd2lkdGg9IjIuNSIgaGVpZ2h0PSIyIiBmaWxsPSIjZmZmIiByeD0iMC41Ii8+PHJlY3QgeD0iMjIiIHk9IjExLjUiIHdpZHRoPSI4IiBoZWlnaHQ9IjIiIGZpbGw9IiNmZmYiIHJ4PSIxIi8+PHJlY3QgeD0iMjIiIHk9IjE4IiB3aWR0aD0iOCIgaGVpZ2h0PSIyIiBmaWxsPSIjZmZmIiByeD0iMSIvPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iZyIgeDE9IjAiIHkxPSIwIiB4Mj0iMzIiIHkyPSIzMiIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPjxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiM2MzY2ZjEiLz48c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM0MzM4Y2EiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48L3N2Zz4=">
   <link rel="stylesheet" type="text/css" href="./index.css">
 </head>
 <body>
   <div id="toast-container" aria-live="polite" aria-atomic="true"></div>
 
-  <!-- 顶部导航 -->
   <header class="site-header">
     <div class="site-header-inner">
       <div class="site-brand">
         <svg class="site-brand-icon" width="28" height="28" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect width="32" height="32" rx="7" fill="url(#lg)"/>
           <rect x="6" y="10" width="8" height="8" fill="white" rx="1.5"/>
-          <path d="M6 10 L10 6 L14 10 Z" fill="white"/>
-          <path d="M16 16 L20 12.5 L20 19.5 Z" fill="white"/>
+          <path d="M6 10L10 6L14 10Z" fill="white"/>
+          <path d="M16 16L20 12.5L20 19.5Z" fill="white"/>
           <rect x="18" y="15" width="2.5" height="2" fill="white" rx="0.5"/>
           <rect x="22" y="11.5" width="8" height="2" fill="white" rx="1"/>
           <rect x="22" y="18" width="8" height="2" fill="white" rx="1"/>
           <defs>
             <linearGradient id="lg" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
-              <stop offset="0%" stop-color="#6366f1"/>
-              <stop offset="100%" stop-color="#4338ca"/>
+              <stop offset="0%" stop-color="#6366f1"/><stop offset="100%" stop-color="#4338ca"/>
             </linearGradient>
           </defs>
         </svg>
@@ -43,34 +41,25 @@
     </div>
   </header>
 
-  <!-- 主内容 -->
   <div class="page-content">
-
-    <!-- 工具卡片 -->
     <div class="tool-wrapper">
-
-      <!-- 卡片标题行 -->
       <div class="tool-header">
         <div>
           <h1 class="tool-title">图片转 Base64</h1>
           <p class="tool-desc">在线将图像转为 Base64 Data URL，本地处理，不上传服务器</p>
         </div>
         <div class="tool-header-badges">
-          <span class="badge">JPG</span>
-          <span class="badge">PNG</span>
-          <span class="badge">SVG</span>
-          <span class="badge">GIF</span>
+          <span class="badge">JPG</span><span class="badge">PNG</span>
+          <span class="badge">SVG</span><span class="badge">GIF</span>
         </div>
       </div>
 
-      <!-- 卡片主体：左右两栏 -->
       <div class="tool-body">
-
         <!-- 左：输入面板 -->
         <div class="tool-panel tool-panel--input">
 
           <!-- 上传区 -->
-          <div class="upload-zone">
+          <div class="upload-zone" id="upload-zone">
             <input id="fileupload" type="file" accept="image/*" multiple />
             <div class="upload-zone-content">
               <svg class="upload-icon" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -84,15 +73,18 @@
             </div>
           </div>
 
+          <!-- 已选文件预览 -->
+          <div id="file-preview" class="file-preview" style="display:none"></div>
+
           <!-- 分隔 -->
           <div class="or-divider"><span>或粘贴 SVG</span></div>
 
-          <!-- SVG 文本输入 -->
+          <!-- SVG 输入 -->
           <div class="textarea">
             <textarea id="textarea" placeholder="粘贴 SVG 代码，或 data:image/svg+xml;base64,… 格式"></textarea>
           </div>
 
-          <!-- 压缩选项（PNG/JPEG 时显示） -->
+          <!-- 压缩选项 -->
           <div id="compress-section" class="compress-section" style="display:none">
             <div class="compress-item">
               <label for="max-width">最大宽度</label>
@@ -104,7 +96,6 @@
               <input type="range" id="quality" min="0.1" max="1" step="0.05" value="0.85" />
               <span id="quality-display">85%</span>
             </div>
-            <button type="button" id="recompress" style="display:none">重新压缩</button>
           </div>
 
           <!-- 操作栏 -->
@@ -119,37 +110,30 @@
 
         <!-- 右：输出面板 -->
         <div class="tool-panel tool-panel--output">
-
-          <!-- 空状态 -->
           <div class="output-empty" id="output-empty">
-            <svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <svg width="52" height="52" viewBox="0 0 52 52" fill="none">
               <rect width="52" height="52" rx="13" fill="currentColor" opacity="0.06"/>
               <circle cx="26" cy="26" r="11" stroke="currentColor" stroke-width="1.5" stroke-dasharray="3 2.5" opacity="0.3"/>
-              <path d="M26 21 L26 31 M21 26 L31 26" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" opacity="0.3"/>
+              <path d="M26 21v10M21 26h10" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" opacity="0.3"/>
             </svg>
             <p>上传图片或粘贴 SVG<br>转换结果将显示在这里</p>
           </div>
 
-          <!-- 结果区 -->
           <section id="result" class="result">
             <div class="result-format">
               <button type="button" class="format-btn format-btn--active" data-format="raw">纯 Base64</button>
               <button type="button" class="format-btn" data-format="css">CSS</button>
               <button type="button" class="format-btn" data-format="html">HTML</button>
             </div>
-
             <div id="result-single">
               <div class="result-wrapper">
                 <div class="result-textarea">
                   <textarea readonly id="result-textarea"></textarea>
                   <span class="result-copy-hint">点击复制</span>
                 </div>
-                <div class="result-thumb">
-                  <img id="result-img" />
-                </div>
+                <div class="result-thumb"><img id="result-img" /></div>
               </div>
             </div>
-
             <div id="result-batch" style="display:none">
               <div class="batch-header">
                 <span id="batch-count"></span>
@@ -159,7 +143,6 @@
             </div>
           </section>
         </div>
-
       </div>
     </div>
 
@@ -167,21 +150,19 @@
     <div class="history-outer">
       <section id="history-section" class="history-section" style="display:none">
         <div class="history-header">
-          <span class="history-title">转换历史</span>
+          <span class="history-title">转换历史<span id="storage-badge" class="storage-badge"></span></span>
           <div class="history-actions">
             <button type="button" id="view-more-history" style="display:none">查看更多</button>
-            <button type="button" id="clear-history">清除</button>
+            <button type="button" id="clear-history">清除全部</button>
           </div>
         </div>
         <div id="history-list" class="history-list"></div>
       </section>
     </div>
 
-    <!-- 页脚 -->
     <footer class="site-footer">
       <div class="site-footer-inner">🔒 所有转换在浏览器本地完成，图片不会上传至服务器</div>
     </footer>
-
   </div>
 
   <!-- 历史抽屉 -->
@@ -200,60 +181,154 @@
   <script type="text/javascript" src="./compiler.js"></script>
   <script type="text/javascript">
     window.onload = function () {
+      // ── HistoryDB（IndexedDB 优先，localStorage 兜底）────────
+      var HistoryDB = (function () {
+        var IDB_NAME = 'img2b64', IDB_VER = 1, STORE = 'history', LS_KEY = 'base64history'
+        var HIST_MAX = 30
+        var _db = null, _idb = false
+
+        function _open() {
+          return new Promise(function (resolve, reject) {
+            var req = indexedDB.open(IDB_NAME, IDB_VER)
+            req.onupgradeneeded = function (e) {
+              var db = e.target.result
+              if (!db.objectStoreNames.contains(STORE)) {
+                db.createObjectStore(STORE, { keyPath: 'id', autoIncrement: true })
+              }
+            }
+            req.onsuccess = function (e) { resolve(e.target.result) }
+            req.onerror   = function () { reject() }
+          })
+        }
+
+        function _lsGet() {
+          try { return JSON.parse(localStorage.getItem(LS_KEY) || '[]') } catch (e) { return [] }
+        }
+        function _lsSet(arr) {
+          try { localStorage.setItem(LS_KEY, JSON.stringify(arr)) } catch (e) {}
+        }
+
+        return {
+          init: function () {
+            if (!window.indexedDB) return Promise.resolve()
+            return _open().then(function (db) { _db = db; _idb = true }).catch(function () {})
+          },
+          isIDB: function () { return _idb },
+          getAll: function () {
+            if (_idb) {
+              return new Promise(function (resolve) {
+                var req = _db.transaction(STORE, 'readonly').objectStore(STORE).getAll()
+                req.onsuccess = function () { resolve((req.result || []).slice().reverse()) }
+                req.onerror   = function () { resolve([]) }
+              })
+            }
+            return Promise.resolve(_lsGet())
+          },
+          add: function (item) {
+            if (_idb) {
+              return new Promise(function (resolve) {
+                var tx = _db.transaction(STORE, 'readwrite'), store = tx.objectStore(STORE)
+                store.add(item)
+                tx.oncomplete = function () {
+                  var tx2 = _db.transaction(STORE, 'readwrite'), s2 = tx2.objectStore(STORE)
+                  var cnt = s2.count()
+                  cnt.onsuccess = function () {
+                    if (cnt.result > HIST_MAX) {
+                      var cur = s2.openCursor(); var del = cnt.result - HIST_MAX
+                      cur.onsuccess = function (e) {
+                        var c = e.target.result
+                        if (c && del > 0) { c.delete(); del--; c.continue() }
+                      }
+                    }
+                  }
+                  resolve()
+                }
+                tx.onerror = resolve
+              })
+            }
+            var arr = _lsGet()
+            arr.unshift(item)
+            if (arr.length > HIST_MAX) arr = arr.slice(0, HIST_MAX)
+            _lsSet(arr)
+            return Promise.resolve()
+          },
+          remove: function (id) {
+            if (_idb) {
+              return new Promise(function (resolve) {
+                var tx = _db.transaction(STORE, 'readwrite')
+                tx.objectStore(STORE).delete(id)
+                tx.oncomplete = resolve; tx.onerror = resolve
+              })
+            }
+            _lsSet(_lsGet().filter(function (x) { return x.id !== id }))
+            return Promise.resolve()
+          },
+          clear: function () {
+            if (_idb) {
+              return new Promise(function (resolve) {
+                var tx = _db.transaction(STORE, 'readwrite')
+                tx.objectStore(STORE).clear()
+                tx.oncomplete = resolve; tx.onerror = resolve
+              })
+            }
+            localStorage.removeItem(LS_KEY)
+            return Promise.resolve()
+          }
+        }
+      })()
+
+      // ── 常量 & 状态 ──────────────────────────────────────────
       var supportType = ['image/svg+xml', 'image/png', 'image/jpeg', 'image/gif', 'image/webp']
       var FILE_SIZE_WARNING = 5 * 1024 * 1024
-      var HISTORY_MAX = 30
       var HISTORY_PREVIEW = 6
-      var currentFormat = 'raw'
-      var currentBase64 = ''
-      var batchResults = []
-      var pendingFiles = []
+      var currentFormat = 'raw', currentBase64 = '', batchResults = [], pendingFiles = []
 
-      var uploader       = document.getElementById('fileupload')
-      var textarea       = document.getElementById('textarea')
-      var convert        = document.getElementById('convert')
-      var checkbox       = document.getElementById('checkbox')
-      var resultSection  = document.getElementById('result')
-      var resultImg      = document.getElementById('result-img')
-      var resultTextarea = document.getElementById('result-textarea')
-      var toastContainer = document.getElementById('toast-container')
-      var formatBtns     = document.querySelectorAll('.format-btn')
-      var resultSingle   = document.getElementById('result-single')
-      var resultBatch    = document.getElementById('result-batch')
-      var batchList      = document.getElementById('batch-list')
-      var batchCount     = document.getElementById('batch-count')
-      var copyAllBtn     = document.getElementById('copy-all')
-      var historyList    = document.getElementById('history-list')
-      var clearHistoryBtn  = document.getElementById('clear-history')
-      var historySection   = document.getElementById('history-section')
-      var viewMoreBtn      = document.getElementById('view-more-history')
-      var drawerOverlay    = document.getElementById('drawer-overlay')
-      var historyDrawer    = document.getElementById('history-drawer')
-      var drawerClose      = document.getElementById('drawer-close')
-      var drawerList       = document.getElementById('drawer-list')
-      var historySearch    = document.getElementById('history-search')
-      var themeToggle      = document.getElementById('theme-toggle')
-      var maxWidthInput    = document.getElementById('max-width')
-      var qualityInput     = document.getElementById('quality')
-      var qualityDisplay   = document.getElementById('quality-display')
-      var compressSection  = document.getElementById('compress-section')
-      var recompressBtn    = document.getElementById('recompress')
-      var outputEmpty      = document.getElementById('output-empty')
+      // ── DOM refs ─────────────────────────────────────────────
+      var uploader        = document.getElementById('fileupload')
+      var textarea        = document.getElementById('textarea')
+      var convert         = document.getElementById('convert')
+      var checkbox        = document.getElementById('checkbox')
+      var resultSection   = document.getElementById('result')
+      var resultImg       = document.getElementById('result-img')
+      var resultTextarea  = document.getElementById('result-textarea')
+      var toastContainer  = document.getElementById('toast-container')
+      var formatBtns      = document.querySelectorAll('.format-btn')
+      var resultSingle    = document.getElementById('result-single')
+      var resultBatch     = document.getElementById('result-batch')
+      var batchList       = document.getElementById('batch-list')
+      var batchCount      = document.getElementById('batch-count')
+      var copyAllBtn      = document.getElementById('copy-all')
+      var historyList     = document.getElementById('history-list')
+      var clearHistoryBtn = document.getElementById('clear-history')
+      var historySection  = document.getElementById('history-section')
+      var viewMoreBtn     = document.getElementById('view-more-history')
+      var drawerOverlay   = document.getElementById('drawer-overlay')
+      var historyDrawer   = document.getElementById('history-drawer')
+      var drawerClose     = document.getElementById('drawer-close')
+      var drawerList      = document.getElementById('drawer-list')
+      var historySearch   = document.getElementById('history-search')
+      var themeToggle     = document.getElementById('theme-toggle')
+      var maxWidthInput   = document.getElementById('max-width')
+      var qualityInput    = document.getElementById('quality')
+      var qualityDisplay  = document.getElementById('quality-display')
+      var compressSection = document.getElementById('compress-section')
+      var outputEmpty     = document.getElementById('output-empty')
+      var uploadZone      = document.getElementById('upload-zone')
+      var filePreview     = document.getElementById('file-preview')
+      var storageBadge    = document.getElementById('storage-badge')
 
       // ── Toast ────────────────────────────────────────────────
-      function showToast(message, type) {
-        var toast = document.createElement('div')
-        toast.className = 'toast toast--' + (type || 'success')
-        toast.textContent = message
-        toastContainer.appendChild(toast)
-        requestAnimationFrame(function () {
-          requestAnimationFrame(function () { toast.classList.add('toast--show') })
-        })
+      function showToast(msg, type) {
+        var t = document.createElement('div')
+        t.className = 'toast toast--' + (type || 'success')
+        t.textContent = msg
+        toastContainer.appendChild(t)
+        requestAnimationFrame(function () { requestAnimationFrame(function () { t.classList.add('toast--show') }) })
         setTimeout(function () {
-          toast.classList.remove('toast--show')
-          toast.addEventListener('transitionend', function handler() {
-            toast.removeEventListener('transitionend', handler)
-            if (toast.parentNode) toast.parentNode.removeChild(toast)
+          t.classList.remove('toast--show')
+          t.addEventListener('transitionend', function h() {
+            t.removeEventListener('transitionend', h)
+            if (t.parentNode) t.parentNode.removeChild(t)
           })
         }, 2500)
       }
@@ -261,31 +336,22 @@
       // ── Clipboard ────────────────────────────────────────────
       function copyText(text) {
         if (navigator.clipboard) {
-          navigator.clipboard.writeText(text).then(function () {
-            showToast('复制成功', 'success')
-          }).catch(function (err) { fallbackCopy(text, err) })
-        } else {
-          fallbackCopy(text, null)
-        }
+          navigator.clipboard.writeText(text)
+            .then(function () { showToast('复制成功', 'success') })
+            .catch(function (err) { fallbackCopy(text, err) })
+        } else { fallbackCopy(text, null) }
       }
-
-      function fallbackCopy(text, originalErr) {
+      function fallbackCopy(text, err) {
         var tmp = document.createElement('textarea')
         tmp.value = text
         tmp.style.cssText = 'position:fixed;top:0;left:0;opacity:0;pointer-events:none'
-        document.body.appendChild(tmp)
-        tmp.focus(); tmp.select()
-        var ok = false
-        try { ok = document.execCommand('copy') } catch (e) {}
+        document.body.appendChild(tmp); tmp.focus(); tmp.select()
+        var ok = false; try { ok = document.execCommand('copy') } catch (e) {}
         document.body.removeChild(tmp)
-        if (ok) {
-          showToast('复制成功', 'success')
-        } else {
-          showToast(originalErr ? originalErr.message : '复制失败，请手动复制', 'error')
-        }
+        showToast(ok ? '复制成功' : (err ? err.message : '复制失败，请手动复制'), ok ? 'success' : 'error')
       }
 
-      // ── Output Format ────────────────────────────────────────
+      // ── Format helpers ───────────────────────────────────────
       function getFormattedOutput(base64, format) {
         if (format === 'css')  return 'background-image: url("' + base64 + '");'
         if (format === 'html') return '<img src="' + base64 + '" alt="" />'
@@ -298,28 +364,32 @@
         themeToggle.textContent = dark ? '☀️' : '🌙'
         localStorage.setItem('theme', dark ? 'dark' : 'light')
       }
-
-      var savedTheme  = localStorage.getItem('theme')
+      var savedTheme = localStorage.getItem('theme')
       var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
       setTheme(savedTheme === 'dark' || (!savedTheme && prefersDark))
-
-      themeToggle.addEventListener('click', function () {
-        setTheme(!document.body.classList.contains('dark'))
-      })
+      themeToggle.addEventListener('click', function () { setTheme(!document.body.classList.contains('dark')) })
 
       // ── History ──────────────────────────────────────────────
-      function loadHistory() {
-        try { return JSON.parse(localStorage.getItem('base64history') || '[]') }
-        catch (e) { return [] }
+      async function saveToHistory(name, base64, mimeType, params) {
+        if (base64.length > 500 * 1024) return
+        var item = {
+          id: Date.now() + '_' + Math.random().toString(36).slice(2),
+          name: name, base64: base64, mimeType: mimeType,
+          time: Date.now(), params: params || {}
+        }
+        await HistoryDB.add(item)
+        renderHistory()
       }
 
-      function saveToHistory(name, base64, mimeType) {
-        if (base64.length > 500 * 1024) return
-        var history = loadHistory()
-        history.unshift({ name: name, base64: base64, mimeType: mimeType, time: Date.now() })
-        if (history.length > HISTORY_MAX) history = history.slice(0, HISTORY_MAX)
-        try { localStorage.setItem('base64history', JSON.stringify(history)) } catch (e) {}
-        renderHistory()
+      function formatParams(item) {
+        var p = item.params || {}
+        if (item.mimeType === 'image/svg+xml') {
+          return p.doubleQuote ? '双引号' : 'SVG'
+        }
+        var parts = []
+        if (p.quality != null) parts.push(Math.round(p.quality * 100) + '%')
+        if (p.maxWidth)        parts.push(p.maxWidth + 'px')
+        return parts.join(' · ') || ''
       }
 
       function makeHistoryCard(item) {
@@ -328,64 +398,83 @@
 
         var thumb = document.createElement('img')
         thumb.className = 'history-thumb'
-        thumb.src = item.base64
-        thumb.alt = item.name
+        thumb.src = item.base64; thumb.alt = item.name
 
         var info = document.createElement('div')
         info.className = 'history-info'
 
+        // 顶行：文件名 + 参数标签 + 时间 + 删除
+        var top = document.createElement('div')
+        top.className = 'history-info-top'
+
         var nameEl = document.createElement('div')
         nameEl.className = 'history-name'
-        nameEl.textContent = item.name
-        nameEl.title = item.name
+        nameEl.textContent = item.name; nameEl.title = item.name
+
+        var ps = formatParams(item)
+        var paramsEl = document.createElement('span')
+        paramsEl.className = 'history-params'
+        paramsEl.textContent = ps || ''
+        paramsEl.style.display = ps ? '' : 'none'
 
         var timeEl = document.createElement('div')
         timeEl.className = 'history-time'
         timeEl.textContent = new Date(item.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
-        var copyBtn = document.createElement('button')
-        copyBtn.type = 'button'
-        copyBtn.className = 'history-copy-btn'
-        copyBtn.textContent = '复制'
-        ;(function (b64) {
-          copyBtn.addEventListener('click', function () {
-            copyText(getFormattedOutput(b64, currentFormat))
+        var delBtn = document.createElement('button')
+        delBtn.type = 'button'; delBtn.className = 'history-delete-btn'; delBtn.textContent = '删除'
+        ;(function (id) {
+          delBtn.addEventListener('click', async function () {
+            await HistoryDB.remove(id)
+            renderHistory()
+            renderDrawer(historySearch.value)
           })
-        })(item.base64)
+        })(item.id)
 
-        info.appendChild(nameEl)
-        info.appendChild(timeEl)
-        info.appendChild(copyBtn)
-        card.appendChild(thumb)
-        card.appendChild(info)
+        top.appendChild(nameEl); top.appendChild(paramsEl)
+        top.appendChild(timeEl); top.appendChild(delBtn)
+
+        // 底行：三格式复制按钮
+        var btns = document.createElement('div')
+        btns.className = 'history-copy-btns'
+        ;['raw', 'css', 'html'].forEach(function (fmt) {
+          var btn = document.createElement('button')
+          btn.type = 'button'; btn.className = 'history-copy-btn'
+          btn.textContent = fmt === 'raw' ? 'Base64' : fmt.toUpperCase()
+          ;(function (b64, f) {
+            btn.addEventListener('click', function () { copyText(getFormattedOutput(b64, f)) })
+          })(item.base64, fmt)
+          btns.appendChild(btn)
+        })
+
+        info.appendChild(top); info.appendChild(btns)
+        card.appendChild(thumb); card.appendChild(info)
         return card
       }
 
       function formatGroupDate(ts) {
-        var d = new Date(ts)
-        var today = new Date()
-        var yesterday = new Date(today)
+        var d = new Date(ts), today = new Date(), yesterday = new Date(today)
         yesterday.setDate(today.getDate() - 1)
-        if (d.toDateString() === today.toDateString()) return '今天'
+        if (d.toDateString() === today.toDateString())     return '今天'
         if (d.toDateString() === yesterday.toDateString()) return '昨天'
         return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0')
       }
 
-      function renderHistory() {
-        var history = loadHistory()
+      async function renderHistory() {
+        var history = await HistoryDB.getAll()
         historySection.style.display = history.length === 0 ? 'none' : 'block'
-        viewMoreBtn.style.display = history.length > HISTORY_PREVIEW ? 'inline-block' : 'none'
+        viewMoreBtn.style.display    = history.length > HISTORY_PREVIEW ? 'inline-block' : 'none'
         historyList.innerHTML = ''
         history.slice(0, HISTORY_PREVIEW).forEach(function (item) {
           historyList.appendChild(makeHistoryCard(item))
         })
       }
 
-      function renderDrawer(keyword) {
-        var history = loadHistory()
+      async function renderDrawer(keyword) {
+        var history = await HistoryDB.getAll()
         if (keyword) {
           var kw = keyword.toLowerCase()
-          history = history.filter(function (item) { return item.name.toLowerCase().indexOf(kw) !== -1 })
+          history = history.filter(function (x) { return x.name.toLowerCase().indexOf(kw) !== -1 })
         }
         drawerList.innerHTML = ''
         var lastGroup = ''
@@ -393,10 +482,8 @@
           var group = formatGroupDate(item.time)
           if (group !== lastGroup) {
             var title = document.createElement('div')
-            title.className = 'drawer-group-title'
-            title.textContent = group
-            drawerList.appendChild(title)
-            lastGroup = group
+            title.className = 'drawer-group-title'; title.textContent = group
+            drawerList.appendChild(title); lastGroup = group
           }
           drawerList.appendChild(makeHistoryCard(item))
         })
@@ -408,12 +495,11 @@
         }
       }
 
-      function openDrawer() {
+      function openDrawer()  {
         renderDrawer(historySearch.value)
         historyDrawer.classList.add('drawer--open')
         drawerOverlay.classList.add('drawer-overlay--show')
       }
-
       function closeDrawer() {
         historyDrawer.classList.remove('drawer--open')
         drawerOverlay.classList.remove('drawer-overlay--show')
@@ -423,15 +509,10 @@
       drawerClose.addEventListener('click', closeDrawer)
       drawerOverlay.addEventListener('click', closeDrawer)
       historySearch.addEventListener('input', function () { renderDrawer(historySearch.value) })
-
-      clearHistoryBtn.addEventListener('click', function () {
-        localStorage.removeItem('base64history')
-        renderHistory()
-        renderDrawer(historySearch.value)
+      clearHistoryBtn.addEventListener('click', async function () {
+        await HistoryDB.clear(); renderHistory(); renderDrawer(historySearch.value)
         showToast('历史已清除', 'success')
       })
-
-      renderHistory()
 
       // ── Compression ──────────────────────────────────────────
       qualityInput.addEventListener('input', function () {
@@ -442,8 +523,7 @@
         return new Promise(function (resolve) {
           var maxWidth = parseInt(maxWidthInput.value) || 1200
           var quality  = parseFloat(qualityInput.value) || 0.85
-          var img = new Image()
-          var blobUrl = URL.createObjectURL(file)
+          var img = new Image(), blobUrl = URL.createObjectURL(file)
           img.onload = function () {
             URL.revokeObjectURL(blobUrl)
             var w = img.naturalWidth, h = img.naturalHeight
@@ -451,12 +531,29 @@
             var canvas = document.createElement('canvas')
             canvas.width = w; canvas.height = h
             canvas.getContext('2d').drawImage(img, 0, 0, w, h)
-            var type = file.type === 'image/png' ? 'image/png' : 'image/jpeg'
-            resolve(canvas.toDataURL(type, quality))
+            resolve(canvas.toDataURL(file.type === 'image/png' ? 'image/png' : 'image/jpeg', quality))
           }
           img.onerror = function () { URL.revokeObjectURL(blobUrl); resolve(null) }
           img.src = blobUrl
         })
+      }
+
+      function processFile(file) {
+        return new Promise(function (resolve) {
+          var canCompress = file.type === 'image/png' || file.type === 'image/jpeg'
+          if (canCompress) {
+            compressImage(file).then(function (compressed) {
+              if (compressed) resolve({ base64: compressed, imgSrc: compressed, name: file.name })
+              else readFileAsDataURL(file, function (b) { resolve(b ? { base64: b, imgSrc: b, name: file.name } : null) })
+            })
+          } else {
+            readFileAsDataURL(file, function (b) { resolve(b ? { base64: b, imgSrc: b, name: file.name } : null) })
+          }
+        })
+      }
+      function readFileAsDataURL(file, cb) {
+        var r = new FileReader(); r.readAsDataURL(file)
+        r.onload = function () { cb(r.result) }; r.onerror = function () { cb(null) }
       }
 
       // ── Result UI ────────────────────────────────────────────
@@ -465,257 +562,209 @@
         resultSection.style.display = show ? 'flex' : 'none'
         outputEmpty.style.display   = show ? 'none' : 'flex'
       }
-
-      function convertDisabled(disabled) { convert.disabled = disabled }
+      function convertDisabled(d) { convert.disabled = d }
       function clearUploader() { uploader.value = '' }
 
       function showSingleResult(base64, imgSrc) {
         currentBase64 = base64
         resultTextarea.value = getFormattedOutput(base64, currentFormat)
         resultImg.src = imgSrc || base64
-        resultSingle.style.display = 'block'
-        resultBatch.style.display  = 'none'
+        resultSingle.style.display = 'block'; resultBatch.style.display = 'none'
         resultToggle('block')
       }
-
       function renderBatchList() {
         batchList.innerHTML = ''
         batchResults.forEach(function (item) {
-          var card = document.createElement('div')
-          card.className = 'batch-item'
-
-          var thumb = document.createElement('img')
-          thumb.className = 'batch-thumb'
-          thumb.src = item.imgSrc || item.base64
-          thumb.alt = item.name
-
-          var info = document.createElement('div')
-          info.className = 'batch-info'
-
-          var nameEl = document.createElement('div')
-          nameEl.className = 'batch-name'
-          nameEl.textContent = item.name
-          nameEl.title = item.name
-
-          var output = document.createElement('textarea')
-          output.className = 'batch-output'
-          output.readOnly = true
-          output.value = getFormattedOutput(item.base64, currentFormat)
-          ;(function (el) {
-            el.addEventListener('click', function () { copyText(el.value) })
-          })(output)
-
-          info.appendChild(nameEl)
-          info.appendChild(output)
-          card.appendChild(thumb)
-          card.appendChild(info)
-          batchList.appendChild(card)
+          var card = document.createElement('div'); card.className = 'batch-item'
+          var thumb = document.createElement('img'); thumb.className = 'batch-thumb'
+          thumb.src = item.imgSrc || item.base64; thumb.alt = item.name
+          var info = document.createElement('div'); info.className = 'batch-info'
+          var nameEl = document.createElement('div'); nameEl.className = 'batch-name'
+          nameEl.textContent = item.name; nameEl.title = item.name
+          var output = document.createElement('textarea'); output.className = 'batch-output'
+          output.readOnly = true; output.value = getFormattedOutput(item.base64, currentFormat)
+          ;(function (el) { el.addEventListener('click', function () { copyText(el.value) }) })(output)
+          info.appendChild(nameEl); info.appendChild(output)
+          card.appendChild(thumb); card.appendChild(info); batchList.appendChild(card)
         })
       }
-
       function showBatchResults(items) {
-        batchResults = items
-        batchCount.textContent = '共 ' + items.length + ' 个文件'
-        resultSingle.style.display = 'none'
-        resultBatch.style.display  = 'block'
-        resultToggle('block')
-        renderBatchList()
+        batchResults = items; batchCount.textContent = '共 ' + items.length + ' 个文件'
+        resultSingle.style.display = 'none'; resultBatch.style.display = 'block'
+        resultToggle('block'); renderBatchList()
       }
 
       // ── Format buttons ────────────────────────────────────────
       for (var i = 0; i < formatBtns.length; i++) {
         formatBtns[i].addEventListener('click', function (e) {
-          for (var j = 0; j < formatBtns.length; j++) {
-            formatBtns[j].classList.remove('format-btn--active')
-          }
+          for (var j = 0; j < formatBtns.length; j++) formatBtns[j].classList.remove('format-btn--active')
           e.currentTarget.classList.add('format-btn--active')
           currentFormat = e.currentTarget.getAttribute('data-format')
           if (currentBase64) resultTextarea.value = getFormattedOutput(currentBase64, currentFormat)
           if (batchResults.length > 0) renderBatchList()
         })
       }
-
       copyAllBtn.addEventListener('click', function () {
-        var all = batchResults.map(function (item) {
-          return getFormattedOutput(item.base64, currentFormat)
-        }).join('\n\n')
-        copyText(all)
+        copyText(batchResults.map(function (x) { return getFormattedOutput(x.base64, currentFormat) }).join('\n\n'))
       })
-
       resultTextarea.addEventListener('click', function () {
         if (resultTextarea.value) copyText(resultTextarea.value)
       })
 
-      // ── SVG Conversion ───────────────────────────────────────
-      function svgToBase64() {
-        var input = textarea.value.trim()
-        var b64prefix = 'data:image/svg+xml;base64,'
-        if (input.indexOf(b64prefix) === 0) {
-          try {
-            input = atob(input.slice(b64prefix.length))
-            textarea.value = input
-          } catch (e) {
-            showToast('Base64 解码失败', 'error')
-            return
-          }
+      // ── Upload file preview ───────────────────────────────────
+      function renderFilePreview() {
+        if (pendingFiles.length === 0) {
+          filePreview.style.display = 'none'
+          uploadZone.classList.remove('upload-zone--has-files')
+          return
         }
-        compressSection.style.display = 'none'
-        recompressBtn.style.display   = 'none'
-        pendingFiles = []
-        var res = ImageToBase64(input, { doubleQuote: checkbox.checked })
-        var base64 = typeof res === 'string' ? res : res.input
-        showSingleResult(base64, base64)
-        saveToHistory('SVG', base64, 'image/svg+xml')
-      }
-
-      // ── File Processing ──────────────────────────────────────
-      function readFileAsDataURL(file, callback) {
-        var reader = new FileReader()
-        reader.readAsDataURL(file)
-        reader.onload  = function () { callback(reader.result) }
-        reader.onerror = function () { callback(null) }
-      }
-
-      function processFile(file) {
-        return new Promise(function (resolve) {
-          var canCompress = file.type === 'image/png' || file.type === 'image/jpeg'
-          if (canCompress) {
-            compressImage(file).then(function (compressed) {
-              if (compressed) {
-                resolve({ base64: compressed, imgSrc: compressed, name: file.name })
+        uploadZone.classList.add('upload-zone--has-files')
+        filePreview.style.display = 'flex'
+        filePreview.innerHTML = ''
+        pendingFiles.forEach(function (file, idx) {
+          var card = document.createElement('div'); card.className = 'file-card'
+          var thumb = document.createElement('img'); thumb.className = 'file-card-thumb'
+          var url = URL.createObjectURL(file); thumb.src = url; thumb.alt = file.name
+          thumb.onload = function () { URL.revokeObjectURL(url) }
+          var name = document.createElement('span'); name.className = 'file-card-name'
+          name.textContent = file.name; name.title = file.name
+          var rm = document.createElement('button'); rm.type = 'button'
+          rm.className = 'file-card-remove'; rm.textContent = '×'
+          ;(function (i) {
+            rm.addEventListener('click', function (e) {
+              e.stopPropagation()
+              pendingFiles.splice(i, 1)
+              renderFilePreview()
+              if (pendingFiles.length === 0) {
+                convertDisabled(true); resultToggle('none')
+                var hasComp = false
+                compressSection.style.display = 'none'
               } else {
-                readFileAsDataURL(file, function (base64) {
-                  resolve(base64 ? { base64: base64, imgSrc: base64, name: file.name } : null)
+                var hasComp = pendingFiles.some(function (f) {
+                  return f.type === 'image/png' || f.type === 'image/jpeg'
                 })
+                compressSection.style.display = hasComp ? 'flex' : 'none'
               }
             })
-          } else {
-            readFileAsDataURL(file, function (base64) {
-              resolve(base64 ? { base64: base64, imgSrc: base64, name: file.name } : null)
-            })
-          }
+          })(idx)
+          card.appendChild(thumb); card.appendChild(name); card.appendChild(rm)
+          filePreview.appendChild(card)
         })
       }
 
-      // ── Batch File Transfer ───────────────────────────────────
+      // ── SVG Conversion ───────────────────────────────────────
+      function svgToBase64() {
+        var input = textarea.value.trim()
+        var b64pre = 'data:image/svg+xml;base64,'
+        if (input.indexOf(b64pre) === 0) {
+          try { input = atob(input.slice(b64pre.length)); textarea.value = input }
+          catch (e) { showToast('Base64 解码失败', 'error'); return }
+        }
+        compressSection.style.display = 'none'; pendingFiles = []
+        var res = ImageToBase64(input, { doubleQuote: checkbox.checked })
+        var base64 = typeof res === 'string' ? res : res.input
+        showSingleResult(base64, base64)
+        saveToHistory('SVG', base64, 'image/svg+xml', { doubleQuote: checkbox.checked })
+      }
+
+      // ── Batch File Transfer（不自动存历史，等用户点转换）────
       async function transferFiles(files) {
         if (!files || files.length === 0) return
         var valid = [], hasInvalid = false
         for (var k = 0; k < files.length; k++) {
           if (supportType.indexOf(files[k].type) !== -1) {
             valid.push(files[k])
-            if (files[k].size > FILE_SIZE_WARNING) {
+            if (files[k].size > FILE_SIZE_WARNING)
               showToast(files[k].name + ' 较大（' + (files[k].size / 1024 / 1024).toFixed(1) + 'MB）', 'warning')
-            }
           } else { hasInvalid = true }
         }
         if (hasInvalid) showToast('已跳过不支持的文件格式', 'error')
         if (valid.length === 0) { clearUploader(); return }
 
+        // 单个 SVG 直接转换并存历史
         if (valid.length === 1 && valid[0].type === 'image/svg+xml') {
           textarea.value = await valid[0].text()
-          convertDisabled(false)
-          compressSection.style.display = 'none'
-          svgToBase64()
-          clearUploader()
-          return
+          convertDisabled(false); compressSection.style.display = 'none'
+          svgToBase64(); clearUploader(); return
         }
 
-        var hasCompressable = valid.some(function (f) {
-          return f.type === 'image/png' || f.type === 'image/jpeg'
-        })
-        compressSection.style.display = hasCompressable ? 'flex' : 'none'
-        recompressBtn.style.display   = hasCompressable ? 'inline-block' : 'none'
-        pendingFiles = valid
-        textarea.value = ''
-        convertDisabled(false)
+        // 非 SVG：记录 pendingFiles，显示预览，不自动存历史
+        var hasComp = valid.some(function (f) { return f.type === 'image/png' || f.type === 'image/jpeg' })
+        compressSection.style.display = hasComp ? 'flex' : 'none'
+        pendingFiles = valid; textarea.value = ''
+        convertDisabled(false); renderFilePreview()
 
+        // 自动预览转换结果（不存历史）
         var results = []
         for (var m = 0; m < valid.length; m++) {
           var res = await processFile(valid[m])
-          if (res) {
-            results.push(res)
-            saveToHistory(res.name, res.base64, valid[m].type)
-          } else {
-            showToast(valid[m].name + ' 处理失败', 'error')
-          }
+          if (res) results.push(res)
+          else showToast(valid[m].name + ' 处理失败', 'error')
         }
-        if (results.length === 1) {
-          showSingleResult(results[0].base64, results[0].imgSrc)
-        } else if (results.length > 1) {
-          showBatchResults(results)
-        }
+        if (results.length === 1)      showSingleResult(results[0].base64, results[0].imgSrc)
+        else if (results.length > 1)   showBatchResults(results)
         clearUploader()
       }
 
-      // ── Recompress ────────────────────────────────────────────
-      recompressBtn.addEventListener('click', async function () {
-        if (pendingFiles.length === 0) return
-        var results = []
-        for (var r = 0; r < pendingFiles.length; r++) {
-          var res = await processFile(pendingFiles[r])
-          if (res) results.push(res)
-        }
-        if (results.length === 1) {
-          showSingleResult(results[0].base64, results[0].imgSrc)
-        } else if (results.length > 1) {
-          showBatchResults(results)
+      // ── Convert button（点击才存历史）────────────────────────
+      convert.addEventListener('click', async function () {
+        if (pendingFiles.length > 0) {
+          // 图片模式：重新压缩并存历史
+          var params = {
+            quality:  parseFloat(qualityInput.value),
+            maxWidth: parseInt(maxWidthInput.value)
+          }
+          var results = []
+          for (var r = 0; r < pendingFiles.length; r++) {
+            var res = await processFile(pendingFiles[r])
+            if (res) results.push(res)
+          }
+          if (results.length === 1) {
+            showSingleResult(results[0].base64, results[0].imgSrc)
+            await saveToHistory(results[0].name, results[0].base64, pendingFiles[0].type, params)
+          } else if (results.length > 1) {
+            showBatchResults(results)
+            for (var s = 0; s < results.length; s++)
+              await saveToHistory(results[s].name, results[s].base64, pendingFiles[s].type, params)
+          }
+        } else if (textarea.value) {
+          if (textarea.value.indexOf('<svg') === -1)
+            showToast('内容不含 <svg 标签，请确认格式', 'warning')
+          svgToBase64()
         }
       })
 
-      // ── Paste Image ──────────────────────────────────────────
-      document.addEventListener('paste', function (event) {
-        var items = event.clipboardData && event.clipboardData.items
+      // ── Textarea events ───────────────────────────────────────
+      textarea.addEventListener('focus', function () { textarea.parentElement.classList.add('focus') })
+      textarea.addEventListener('blur',  function () { textarea.parentElement.classList.remove('focus') })
+      textarea.addEventListener('input', function (e) {
+        if (e.target.value) {
+          convertDisabled(false); compressSection.style.display = 'none'; pendingFiles = []; renderFilePreview()
+        } else { resultToggle('none'); convertDisabled(true) }
+      })
+
+      // ── File & Drop events ────────────────────────────────────
+      uploader.addEventListener('change', function (e) { transferFiles(e.target.files) })
+      document.addEventListener('drop', function (e) { transferFiles(e.dataTransfer.files) })
+      document.ondrop     = function (e) { e.preventDefault() }
+      document.ondragover = function (e) { e.preventDefault() }
+      document.addEventListener('paste', function (e) {
+        var items = e.clipboardData && e.clipboardData.items
         if (!items) return
         var files = []
         for (var p = 0; p < items.length; p++) {
           if (items[p].kind === 'file' && items[p].type.indexOf('image/') === 0) {
-            var f = items[p].getAsFile()
-            if (f) files.push(f)
+            var f = items[p].getAsFile(); if (f) files.push(f)
           }
         }
         if (files.length > 0) transferFiles(files)
       })
 
-      // ── Textarea events ───────────────────────────────────────
-      textarea.addEventListener('focus', function () {
-        textarea.parentElement.classList.add('focus')
+      // ── Init ─────────────────────────────────────────────────
+      HistoryDB.init().then(function () {
+        storageBadge.textContent = HistoryDB.isIDB() ? 'IndexedDB' : 'localStorage'
+        renderHistory()
       })
-      textarea.addEventListener('blur', function () {
-        textarea.parentElement.classList.remove('focus')
-      })
-      textarea.addEventListener('input', function (event) {
-        if (event.target.value) {
-          convertDisabled(false)
-          compressSection.style.display = 'none'
-          recompressBtn.style.display   = 'none'
-          pendingFiles = []
-        } else {
-          resultToggle('none')
-          convertDisabled(true)
-        }
-      })
-
-      convert.addEventListener('click', function () {
-        if (textarea.value) {
-          if (textarea.value.indexOf('<svg') === -1) {
-            showToast('内容不含 <svg 标签，请确认格式', 'warning')
-          }
-          svgToBase64()
-        } else if (uploader.files.length === 0) {
-          resultToggle('none')
-        }
-      })
-
-      uploader.addEventListener('change', function (event) {
-        transferFiles(event.target.files)
-      })
-
-      document.addEventListener('drop', function (event) {
-        transferFiles(event.dataTransfer.files)
-      })
-      document.ondrop     = function (event) { event.preventDefault() }
-      document.ondragover = function (event) { event.preventDefault() }
     }
   </script>
 </body>


### PR DESCRIPTION
- 上传图片后在上传区下方显示缩略图预览，支持逐个删除
- 图片上传后仅预览，不自动存历史；点击「开始转换」才保存（含压缩参数）
- 历史记录支持删除单条
- 历史每条新增三格式复制按钮（Base64 / CSS / HTML）
- 历史卡片显示转换参数（质量 / 最大宽度 / SVG 模式）
- 存储层优先使用 IndexedDB，不支持时回退 localStorage，顶部显示当前存储类型
- 移除独立「重新压缩」按钮，统一由「开始转换」触发