### PR TITLE
fix: 使用说明宽度、SVG粘贴直接显示结果、格式标签样式统一

### DIFF
--- a/index.css
+++ b/index.css
@@ -1305,11 +1305,6 @@ button.history-copy-btn:hover {
   margin-bottom: 14px;
   flex-shrink: 0;
 }
-.svg-format-label {
-  font-size: 12px;
-  color: var(--text-secondary);
-  transition: color 0.3s;
-}
 
 /* ── Batch item size ────────────────────────────────────────── */
 .batch-size {
@@ -1358,7 +1353,7 @@ button.history-copy-btn:hover {
 .result-type-badge--webp { background: #06b6d4; }
 
 /* ── Usage section ───────────────────────────────────────────── */
-.usage-section { margin: 32px auto 0; padding: 0 20px; }
+.usage-section { margin: 32px auto 0; }
 .usage-title { font-size: 16px; font-weight: 600; color: var(--text); margin-bottom: 0; }
 .usage-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
 .usage-card {

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
 
           <section id="result" class="result">
             <div id="result-format-svg" class="result-format-svg" style="display:none">
-              <span class="svg-format-label">输出格式：HTML img 标签</span>
+              <span class="format-btn format-btn--active" style="cursor:default;pointer-events:none;">HTML img 标签</span>
             </div>
             <div id="result-format-tabs" class="result-format">
               <button type="button" class="format-btn format-btn--active" data-format="raw">纯 Base64</button>
@@ -966,12 +966,9 @@
         var IMG_B64 = /^data:image\/(png|jpe?g|gif|webp);base64,/i
 
         if (text.indexOf(SVG_B64) === 0) {
-          // SVG Base64 → 解码为 SVG 标签
-          try {
-            textarea.value = atob(text.slice(SVG_B64.length))
-            textarea.dispatchEvent(new Event('input'))
-            showToast('已解码为 SVG 代码', 'success')
-          } catch (err) { showToast('SVG Base64 解码失败', 'error') }
+          textarea.value = ''
+          showSingleResult(text, text, 'image/svg+xml', true)
+          showToast('已识别 SVG Base64，结果已显示', 'success')
         } else if (text.indexOf(SVG_URI) === 0) {
           // SVG URI 编码 → 解码为 SVG 标签
           try {


### PR DESCRIPTION
1. 移除 .usage-section 多余 padding，与主内容区等宽
2. 粘贴 base64 SVG 时直接显示结果，不再解码回填输入框
3. tag-only 模式格式指示器改用与 format-btn 一致的 pill 样式